### PR TITLE
add separator between adapter statuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ description: Quickly compare and learn service meshes like Istio, Linkerd, Envoy
 						</thead>
 						<tbody>
 						<tr>
-							<td rowspan="6" class="stable-adapters">stable</td>
+							<td rowspan="7" class="stable-adapters">stable</td>
 						</tr>
 						<tr>
 							<td><a href="https://github.com/layer5io/meshery-istio">
@@ -77,13 +77,14 @@ description: Quickly compare and learn service meshes like Istio, Linkerd, Envoy
 								<img src='images/nsm.svg' alt='Network Mesh' class="adapter-logo">Meshery adapter for Network Service Mesh</a>
 							</td>
 						</tr>
+						<tr><td class="stable-adapters"></td></tr>
 						<tr>
 							<td rowspan="2" class="beta-adapters">beta</td>
 							<td class="no-adapters">None</td>
 						</tr>
 						<tr><td class="beta-adapters"></td></tr>
 						<tr>
-							<td rowspan="5" class="alpha-adapters">alpha</td>
+							<td rowspan="6" class="alpha-adapters">alpha</td>
 						</tr>
 						<tr>
 							<td><a href="https://github.com/layer5io/meshery-maesh">
@@ -104,6 +105,7 @@ description: Quickly compare and learn service meshes like Istio, Linkerd, Envoy
 								<img src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQksHj15DkID308qQw3cmkQrRULPxyzbVquSZVev-9dj1L6sPs-rQ&s' alt='Citrix CPX Service Mesh' class="adapter-logo">Meshery adapter for Citrix CPX</a>
 							</td>
 						</tr>
+						<tr><td class="alpha-adapters"></td></tr>
 						</tbody>
 					</table>
 


### PR DESCRIPTION
Provide better visual separation between different status levels of adapters.

**Before:**
<img width="474" alt="Screen Shot 2020-01-05 at 10 01 10 PM" src="https://user-images.githubusercontent.com/7570704/71794397-ef3e5c80-3006-11ea-94f5-ce44ceec64cc.png">

**After:**
<img width="469" alt="Screen Shot 2020-01-05 at 10 06 09 PM" src="https://user-images.githubusercontent.com/7570704/71794554-ad61e600-3007-11ea-806b-5003309d3652.png">

